### PR TITLE
Give client more ability to configure inputs and outputs

### DIFF
--- a/src/main/scala/eu/unicredit/swagger/FileManagement.scala
+++ b/src/main/scala/eu/unicredit/swagger/FileManagement.scala
@@ -17,13 +17,13 @@ package eu.unicredit.swagger
 import java.io.File
 
 object FolderCreator {
- 
+
   def genPackage(base: String, packageName: String): File = {
-    packageName.split('.').foldLeft(new File(base))((act, item) => {
-     val file = new File(act, item)
-     if (!file.exists()) file.mkdir()
-     file
-    })
+    val packagePath = base + File.separator + packageName.replace(".", File.separator)
+    val packageDir = new File(packagePath)
+    packageDir.mkdirs()
+
+    packageDir
   }
 
 }
@@ -31,8 +31,8 @@ object FolderCreator {
 object FileWriter {
   import java.nio.file.Files
   import java.nio.file.Paths
-  
+
   def writeToFile(f: File, s: String) =
     Files.write(Paths.get(f.getAbsolutePath), s.getBytes)
-  
+
 }


### PR DESCRIPTION
Thanks for putting this sbt plugin together! This PR adds the following keys:
- swaggerModelCodeTargetDir. The models get written into this source directory upon `swaggerCodeGen`
- swaggerPlayClientCodeTargetDir. Play client request generators get written into this source directory upon `swaggerPlayClientCodeGen`
- swaggerPlayServerRoutesFile. The play server routes file gets written to this path.
- swaggerGeneratePlayControllers. `true` if controllers should be generated
  - Generating controllers is problematic because it can overwrite user-authored code!
