### PR TITLE
upgrade versions:

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Moreover, you can do it directly within an `sbt` project.
 
 ## Compatibility
 
-This code generator is designed specifically for Swagger Spec Version 2.0. Moreover, it relies on [Play! Framework](http://www.playframework.com/) 2.5 for Json marshalling/unmarshalling, server- and client-side code.
+This code generator is designed specifically for Swagger Spec Version 2.0. Moreover, it relies on [Play! Framework](http://www.playframework.com/) 2.6 for Json marshalling/unmarshalling, server- and client-side code.
 
 ## Install
 
@@ -77,10 +77,9 @@ Moreover, you can extend this plugin by providing alternative implementations of
 
 ## Dependencies
 
-- scala version 2.11.X
-- play-sbt-plugin 2.5.3
-- play-json 2.5.3
-- play-ws 2.5.3 (only if you use client)
+- scala version 2.12.X
+- play-ws-standalone-json 1.1.3
+- play-ahc-ws-standalone 1.1.3 (only if you use client)
 
 ### Limitations
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,17 @@
+import sbt.Keys.crossSbtVersions
+import xerial.sbt.Sonatype.sonatypeSettings
+
 lazy val common = Seq(
     organization := "eu.unicredit",
     version := "0.0.11-SNAPSHOT",
-    crossScalaVersions := Seq("2.10.4"),
-    scalacOptions ++= Seq("-target:jvm-1.7", "-feature", "-deprecation", "-language:_"),
+    crossSbtVersions := List("0.13.16", "1.0.4"),
+    scalaVersion := {
+      (sbtBinaryVersion in pluginCrossBuild).value match {
+        case "0.13" => "2.10.4"
+        case _      => "2.12.4"
+      }
+    },
+    scalacOptions ++= Seq("-feature", "-deprecation", "-language:_"),
     resolvers += Resolver.sonatypeRepo("releases")
   ) ++ sonatypePublish
 

--- a/lib/src/main/scala/eu/unicredit/swagger/generators/DefaultClientGenerator.scala
+++ b/lib/src/main/scala/eu/unicredit/swagger/generators/DefaultClientGenerator.scala
@@ -22,11 +22,16 @@ import eu.unicredit.swagger.StringUtils._
 import io.swagger.parser.SwaggerParser
 import io.swagger.models._
 import io.swagger.models.parameters._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode {
 
-  def clientNameFromFileName(fn: String) = objectNameFromFileName(fn, "Client")
+  def clientNameFromFileName(fn: String): String = objectNameFromFileName(fn, "Client")
+
+  /** Errors when the given string does not start with capital letter */
+  def lowerFirstLetter(pascal: String): String = pascal.toList match {
+    case firstLetter :: rest if firstLetter.isUpper => (firstLetter.toLower :: rest).mkString
+  }
 
   def generate(fileName: String, packageName: String): Iterable[SyntaxString] = {
     val swagger = new SwaggerParser().read(fileName)
@@ -39,8 +44,14 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
     val clientName =
       clientNameFromFileName(fileName)
 
+    val clientConfigName =
+      s"${clientName}Config"
+
+    val clientConfigMemberName =
+      lowerFirstLetter(clientConfigName)
+
     val completePaths =
-      swagger.getPaths.keySet().toSeq
+      swagger.getPaths.keySet().asScala.toList
 
     def composeClient(p: String): Seq[Tree] = {
       val path = swagger.getPath(p)
@@ -66,7 +77,7 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
 
         val url = doUrl(basePath, p)
 
-        genClientMethod(methodName, url, verb, op.getParameters, okRespType)
+        genClientMethod(methodName, url, verb, op.getParameters.asScala.toList, okRespType)
       }
     }
 
@@ -76,11 +87,24 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
           IMPORT(packageName, "_"),
           IMPORT(packageName + ".json", "_"),
           IMPORT("play.api.libs.ws", "_"),
+          IMPORT("play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue"),
+          IMPORT("play.api.libs.ws.JsonBodyReadables.readableAsJson"),
           IMPORT("play.api.libs.json", "_"),
           IMPORT("javax.inject", "_"),
-          IMPORT("play.api.libs.concurrent.Execution.Implicits", "_")
+          IMPORT("scala.concurrent.ExecutionContext")
         )
       } inPackage clientPackageName
+
+    def RENDER_SCHEME_MEMBER: Tree =
+      VAL("scheme", StringClass).withFlags(Flags.PRIVATE) := IF(REF(clientConfigMemberName) DOT "ssl") THEN LIT("https") ELSE LIT(
+        "http")
+    def RENDER_BASE_URL_MEMBER: Tree =
+      VAL("baseUrl", StringClass) := INTERP(StringContext_s,
+                                            REF("scheme"),
+                                            LIT("://"),
+                                            REF(clientConfigMemberName) DOT "host",
+                                            LIT(":"),
+                                            REF(clientConfigMemberName) DOT "port")
 
     val RENDER_URL_PARAMS: Tree =
       DEFINFER("_render_url_params") withFlags Flags.PRIVATE withParams PARAM(
@@ -89,9 +113,8 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
         Seq(
           VAL("parts") := (
             REF("pairs")
-              DOT "collect" APPLY BLOCK(
-              CASE(TUPLE(ID("k"), REF("Some") UNAPPLY ID("v"))) ==> (REF("k") INFIX ("+", LIT("=")) INFIX ("+", REF(
-                "v"))))
+              DOT "collect" APPLY BLOCK(CASE(TUPLE(ID("k"), REF("Some") UNAPPLY ID("v"))) ==> (REF("k") INFIX ("+", LIT(
+              "=")) INFIX ("+", REF("v"))))
           ),
           IF(REF("parts") DOT "nonEmpty")
             THEN (
@@ -110,11 +133,18 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
             (REF("k") INFIX ("->", REF("v") DOT "toString")))
         ))
 
-    val tree = CLASSDEF(clientName + " @Inject() (WS: WSClient)") withParams PARAM("baseUrl", StringClass) := BLOCK {
-      completePaths.flatMap(composeClient) :+ RENDER_URL_PARAMS :+ RENDER_HEADER_PARAMS
+    val clientConfigTree = CASECLASSDEF(clientConfigName)
+      .withParams(PARAM("host", StringClass) := LIT("localhost"),
+                  PARAM("port", IntClass),
+                  PARAM("ssl", BooleanClass) := FALSE)
+      .tree
+
+    val tree = CLASSDEF(clientName + s" @Inject() (WS: StandaloneWSClient, $clientConfigMemberName: $clientConfigName)")
+      .withParams(PARAM("ec", "ExecutionContext") withFlags Flags.IMPLICIT) := BLOCK {
+      Seq(RENDER_SCHEME_MEMBER, RENDER_BASE_URL_MEMBER) ++ (completePaths.flatMap(composeClient) :+ RENDER_URL_PARAMS :+ RENDER_HEADER_PARAMS)
     }
 
-    Seq(SyntaxString(clientName + ".scala", treeToString(imports), treeToString(tree)))
+    Seq(SyntaxString(clientName + ".scala", treeToString(imports), treeToString(clientConfigTree, "", tree)))
   }
 
   def genClientMethod(methodName: String,
@@ -179,20 +209,26 @@ class DefaultClientGenerator extends ClientGenerator with SharedServerClientCode
                   PAREN(REF("resp") DOT "status" INFIX ("<=", LIT(299)))
                 )
               ).THEN(
-                  respType._2.map { typ =>
-                    {
-                      REF("Json") DOT "parse" APPLY (REF("resp") DOT "body") DOT
-                        "as" APPLYTYPE typ
+                  respType._2
+                    .map { typ =>
+                      {
+                        REF("Json") DOT "parse" APPLY (REF("resp") DOT "body") DOT
+                          "as" APPLYTYPE typ
+                      }
                     }
-                  }.getOrElse(REF("Unit"))
+                    .getOrElse(REF("Unit"))
                 )
                 .ELSE(
-                  THROW(RuntimeExceptionClass,
-                        INFIX_CHAIN("+",
-                                    LIT("unexpected response status: "),
-                                    REF("resp") DOT "status",
-                                    LIT(" "),
-                                    REF("resp") DOT "body"))
+                  THROW(
+                    RuntimeExceptionClass,
+                    INTERP(
+                      StringContext_s,
+                      LIT("unexpected response status: "),
+                      REF("resp") DOT "status",
+                      LIT(" "),
+                      REF("resp") DOT "body"
+                    )
+                  )
                 )
             )
           }

--- a/lib/src/main/scala/eu/unicredit/swagger/generators/SharedServerClientCode.scala
+++ b/lib/src/main/scala/eu/unicredit/swagger/generators/SharedServerClientCode.scala
@@ -48,10 +48,10 @@ trait SharedServerClientCode extends SwaggerConversion {
   def getMethodParams(params: Seq[Parameter]): Map[String, ValDef] =
     params
       .filter {
-        case _: PathParameter => true
-        case _: QueryParameter => true
+        case _: PathParameter   => true
+        case _: QueryParameter  => true
         case _: HeaderParameter => true
-        case _: BodyParameter => false
+        case _: BodyParameter   => false
         case x =>
           println(
             s"unmanaged parameter type for parameter ${x.getName}, please contact the developer to implement it XD")
@@ -59,8 +59,8 @@ trait SharedServerClientCode extends SwaggerConversion {
       }
       .sortBy { //the order must be verified...
         case _: HeaderParameter => 1
-        case _: PathParameter => 2
-        case _: QueryParameter => 3
+        case _: PathParameter   => 2
+        case _: QueryParameter  => 3
         // other subtypes have been removed already
       }
       .map(p => {

--- a/plugin/src/main/scala/eu/unicredit/swagger/dependencies/Dependencies.scala
+++ b/plugin/src/main/scala/eu/unicredit/swagger/dependencies/Dependencies.scala
@@ -16,8 +16,8 @@ package eu.unicredit.swagger.dependencies
 
 import sbt._
 
-object DefaultPlay {
-  val version = "2.5.3"
+object PlayWsStandalone {
+  val version = "1.1.3"
 }
 
 object DefaultModelGenerator {
@@ -26,7 +26,7 @@ object DefaultModelGenerator {
 
 object DefaultJsonGenerator {
   def dependencies: Seq[sbt.ModuleID] = Seq(
-    "com.typesafe.play" %% "play-json" % DefaultPlay.version
+    "com.typesafe.play" %% "play-ws-standalone-json" % PlayWsStandalone.version
   )
 }
 
@@ -36,6 +36,6 @@ object DefaultServerGenerator {
 
 object DefaultClientGenerator {
   def dependencies: Seq[sbt.ModuleID] = Seq(
-    "com.typesafe.play" %% "play-ws" % DefaultPlay.version
+    "com.typesafe.play" %% "play-ahc-ws-standalone" % PlayWsStandalone.version
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.6.3")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"


### PR DESCRIPTION
- Use play stand alone client so that clients will not have to bring the entire Play Framework in order to use the Play Json and WS libraries.
- Cross build sbt (1.0.4 and 0.13.16)
- Use scala 2.12 for sbt 1