### PR TITLE
supporting "-" in header param of client generated code

### DIFF
--- a/lib/src/main/scala/eu/unicredit/swagger/generators/SharedServerClientCode.scala
+++ b/lib/src/main/scala/eu/unicredit/swagger/generators/SharedServerClientCode.scala
@@ -64,7 +64,8 @@ trait SharedServerClientCode extends SwaggerConversion {
         // other subtypes have been removed already
       }
       .map(p => {
-        (p.getName, PARAM(p.getName, paramType(p)): ValDef)
+        val name = if (p.getName.contains("-")) s"`${p.getName}`" else p.getName
+        (name, PARAM(name, paramType(p)): ValDef)
       })
       .toMap
 


### PR DESCRIPTION
this code supports creating client code when yaml contains headers that contain "-", e.g "some-name" instead of "somename".
(some-name as method parameters does not compile and needs to be wrapped by ')